### PR TITLE
fix for segfault in RLC AM: retransmission list should hold unique TX…

### DIFF
--- a/ue/hdr/upper/rlc_am.h
+++ b/ue/hdr/upper/rlc_am.h
@@ -36,7 +36,7 @@
 #include "upper/rlc_common.h"
 #include <boost/thread/mutex.hpp>
 #include <map>
-#include <queue>
+#include <set>
 
 namespace srsue {
 
@@ -92,7 +92,7 @@ private:
 
   // Tx and Rx windows
   std::map<uint32_t, rlc_amd_tx_pdu_t>  tx_window;
-  std::queue<uint32_t>                  retx_queue;
+  std::set<uint32_t>                    retx_set;
   std::map<uint32_t, rlc_amd_rx_pdu_t>  rx_window;
 
   // RX SDU buffers

--- a/ue/src/upper/rlc_am.cc
+++ b/ue/src/upper/rlc_am.cc
@@ -139,9 +139,8 @@ void rlc_am::reset()
   }
   tx_window.clear();
 
-  // Drop all messages in RETX queue
-  while(retx_queue.size() > 0)
-    retx_queue.pop();
+  // Drop all messages in RETX set
+  retx_set.clear();
 
 }
 
@@ -179,10 +178,14 @@ uint32_t rlc_am::get_buffer_state()
     return prepare_status();
 
   // Bytes needed for retx
-  if(retx_queue.size() > 0) {
-    if (tx_window[retx_queue.front()].buf) {
-      return tx_window[retx_queue.front()].buf->N_bytes;      
+  if(!retx_set.empty()) {
+    std::set<uint32_t>::const_iterator const retx_it = retx_set.begin();
+    std::map<uint32_t, rlc_amd_tx_pdu_t>::iterator const tx_it =
+      tx_window.find(*retx_it);
+    if (tx_window.end() != tx_it) {
+      return tx_it->second.buf->N_bytes;      
     } else {
+      log->warning("tx_window %u not found\n", (unsigned) *retx_it);
       return 0; 
     }
   }
@@ -218,7 +221,7 @@ int rlc_am::read_pdu(uint8_t *payload, uint32_t nof_bytes)
     return build_status_pdu(payload, nof_bytes);
 
   // RETX if required
-  if(retx_queue.size() > 0)
+  if(!retx_set.empty())
     return build_retx_pdu(payload, nof_bytes);
 
   // Build a PDU from SDUs
@@ -334,7 +337,8 @@ int  rlc_am::build_status_pdu(uint8_t *payload, uint32_t nof_bytes)
 
 int  rlc_am::build_retx_pdu(uint8_t *payload, uint32_t nof_bytes)
 {
-  uint32_t sn = retx_queue.front();
+  std::set<uint32_t>::const_iterator const retx_it = retx_set.begin();
+  uint32_t const sn = *retx_it;
   if(tx_window[sn].buf->N_bytes <= nof_bytes)
   {
     pdu_without_poll++;
@@ -350,7 +354,7 @@ int  rlc_am::build_retx_pdu(uint8_t *payload, uint32_t nof_bytes)
       tx_window[sn].buf->msg[0] &= ~(1 << 5); // Clear polling bit directly in PDU
     }
     memcpy(payload, tx_window[sn].buf->msg, tx_window[sn].buf->N_bytes);
-    retx_queue.pop();
+    retx_set.erase(retx_it);
     tx_window[sn].retx_count++;
     if(tx_window[sn].retx_count >= max_retx_thresh)
       rrc->max_retx_attempted();
@@ -606,7 +610,7 @@ void rlc_am::handle_control_pdu(uint8_t *payload, uint32_t nof_bytes)
       it = tx_window.find(i);
       if(tx_window.end() != it)
       {
-        retx_queue.push(i);
+        retx_set.insert(i);
       }
     }else{
       it = tx_window.find(i);


### PR DESCRIPTION
Hi,

I'm testing srsUE with Amarisoft eNB. Uder some circumstances, with connectivity problems and high packet loss, srsUE would segfault. Problem was traced to RLC AM (also see attached logs)
[run.txt](https://github.com/srsLTE/srsUE/files/238849/run.txt)
[ue.txt](https://github.com/srsLTE/srsUE/files/238850/ue.txt)

#0  0x00000000004a577b in srsue::byte_buffer_t::reset() ()
#1  0x00000000004c43d8 in srsue::buffer_pool::deallocate(srsue::byte_buffer_t*) ()
#2  0x00000000004b685d in srsue::rlc_am::reset() ()
#3  0x00000000004c0f2d in srsue::rlc_entity::init(srsue::rlc_mode_t, srslte::log*, unsigned int, srsue::pdcp_interface_rlc*, srsue::rrc_interface_rlc*, srsue::mac_interface_timers*) ()
#4  0x00000000004b5cc2 in srsue::rlc::add_bearer(unsigned int, LIBLTE_RRC_RLC_CONFIG_STRUCT*) ()
#5  0x00000000004a4aff in srsue::rrc::add_drb(LIBLTE_RRC_DRB_TO_ADD_MOD_STRUCT*) ()

The byte_buffer_t passed to deallocate() was null. This happened because of rogue entry in tx_window map, created when checking buf existence in get_buffer_state(). The front value in retx_queue referenced an erased entry. This in turn happened because of choice to use std::queue for retransmission management. Under circumstances I managed to get, an ID for tx_window map entry would be pushed to retx_queue multiple times (it would contain for example: 3, 4, 5, 6, 7, 5, 6, 7). When ACK for that entry appeared, a front value was popped, then entry erased but that same value would still be existing in the queue. Then its entry in the map would be erased. After some pop() operations, front of the queue would reference that non-existent value, which would be passed to get_buffer_state(), which would create new map entry with all fields zeroed out.
In my patch I propose changing the retx list data type to std::set, which can only contain unique values. Removal of a value ensures that no other copies of it exist in the set. It makes sense to me: when an ACK is received for some PDU, it shouldn't be scheduled for retransmission anymore.

I tested the patch only with this single case of poor connectivity and couldn't trigger the segfault anymore.

Regards,
Matt