### PR TITLE
cqi: only send cqi report during rar if delay flag is not set

### DIFF
--- a/ue/src/phy/phch_worker.cc
+++ b/ue/src/phy/phch_worker.cc
@@ -507,7 +507,7 @@ bool phch_worker::decode_pdcch_ul(mac_interface_phy::mac_grant_t* grant)
     grant->rnti_type = SRSLTE_RNTI_TEMP;
     grant->is_from_rar = true; 
     Debug("RAR grant found for TTI=%d\n", tti);
-    rar_cqi_request = rar_grant.cqi_request;    
+    rar_cqi_request = (rar_grant.ul_delay) ? false : rar_grant.cqi_request; // delay reporting if delay flag is set
     ret = true;  
   } else {
     ul_rnti = phy->get_ul_rnti(tti);


### PR DESCRIPTION
Hey,
I stumbled across this one in TS 36.213 in subclause 7.2.1 "The UE shall postpone aperiodic
CQI, PMI and RI reporting to the next available UL subframe if the UL delay field is set to 1".